### PR TITLE
Remove spaces from setup.cfg

### DIFF
--- a/setup-config-fix
+++ b/setup-config-fix
@@ -1,0 +1,2 @@
+[metadata]
+description-file = README.md

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[metadata]
-    description-file = README.md


### PR DESCRIPTION
The spaces seem to throw an error while running the setup.py script.