### PR TITLE
Show all executed steps

### DIFF
--- a/behave_teamcity/__init__.py
+++ b/behave_teamcity/__init__.py
@@ -32,6 +32,9 @@ class TeamcityFormatter(Formatter):
         self.current_step = step
 
     def result(self, step_result):
+        text = u'%6s %s ... ' % (step_result.keyword, step_result.name)
+        self.msg.progressMessage(text)
+        
         if self.current_scenario.status == "untested":
             return
 

--- a/behave_teamcity/__init__.py
+++ b/behave_teamcity/__init__.py
@@ -40,7 +40,7 @@ class TeamcityFormatter(Formatter):
                              duration=str(self.current_scenario.duration), flowId=None)
 
         if self.current_scenario.status == "failed":
-            name = self.current_step.name
+            name = step_result.name
 
             error_msg = u"Step failed: {}".format(name)
             if self.current_step.table:


### PR DESCRIPTION
I've added 2 changes:
1 bugfix: In previous version, when a test failed, instead of showing the failed step, it showed the last step.
1 improvement: Now all steps can be found on the build log

Examples of current status:
*Passed test*
![passed_test](https://cloud.githubusercontent.com/assets/11614909/24194841/d9a20918-0ef7-11e7-8af9-ac764f6a1b44.PNG)

*Failed test*
![failed_test](https://cloud.githubusercontent.com/assets/11614909/24194836/d76aebec-0ef7-11e7-9b90-9959cdc297d8.PNG)

Verified in Teamcity 9

